### PR TITLE
Remove leftover debugger in Canvas

### DIFF
--- a/scalelsd/base/show/canvas.py
+++ b/scalelsd/base/show/canvas.py
@@ -140,7 +140,6 @@ class Canvas:
             fig.savefig(fig_file)
         if cls.show:
             plt.show()
-            import pdb;pdb.set_trace()
         plt.close(fig)
 
 def white_screen(ax, alpha=0.9):


### PR DESCRIPTION
## Summary
- clean up Canvas.image to avoid unintentional pdb breakpoints

## Testing
- `python -m py_compile scalelsd/base/show/canvas.py`


------
https://chatgpt.com/codex/tasks/task_e_68565d22c900833386944fe7c41eb473